### PR TITLE
fix: drop the trailing blank line in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,4 +115,3 @@
 - fix: Audio file to root for example.
 
 ## 0.1.0 (2022-09-12)
-


### PR DESCRIPTION
`CHANGELOG.md` ended with a blank line. markdownlint counts that together with the end of the file as two consecutive blank lines and reports MD012.

The file now ends with a single newline. One line is removed and nothing else changes, so the commit carries `[skip ci]`: a trailing blank line cannot alter the rendered page.